### PR TITLE
4827: Align layout for action buttons

### DIFF
--- a/themes/ddbasic/sass/components/class.scss
+++ b/themes/ddbasic/sass/components/class.scss
@@ -157,10 +157,25 @@ body > .ding2-site-template {
     background-color $speed $ease,
     color $speed $ease
   );
-  color: $charcoal-opacity-dark;
+
   background-color: $grey;
+  color: $charcoal-opacity-dark;
   padding: 20px 80px 14px 15px;
   border-radius: $round-corner;
+  display: block;
+  font-size: 1em;
+  margin-bottom: 15px;
+  &:hover {
+    background-color: $grey-dark;
+    color: $white;
+  }
+
+  @include media($mobile) {
+    @include span-columns(6);
+    margin-bottom: 10px;
+    padding-right: 0;
+  }
+
   &.reserve-button,
   &.button-see-online,
   &.button-order {
@@ -171,11 +186,7 @@ body > .ding2-site-template {
       color: $white;
     }
   }
-  &.button-see-online,
-  &.button-order,
-  &.other-formats {
-    display: block;
-  }
+
   &.reserve-button {
     display: none;
     &.reservable,
@@ -184,6 +195,7 @@ body > .ding2-site-template {
     }
   }
 }
+
 
 // Submit-button with icon
 //


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4827#change-48140

#### Description

Align action buttons on material

#### Screenshot of the result

![Screenshot 2020-05-25 11 57 58](https://user-images.githubusercontent.com/332915/82803692-45f6e680-9e81-11ea-9ada-0c0c8ed68308.png)


#### Checklist

- [X] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [X] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [X] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

I see that the react component for the `Add to list` button/function does not use the class .action-button but tries to mimic the styles instead. This should be addressed in another issue since it does not follow the styleguide and it breaks in mobile view.
