### PR TITLE
Change use of $grey-dark for background to $grey

### DIFF
--- a/themes/ddbasic/sass/components/panel/account.scss
+++ b/themes/ddbasic/sass/components/panel/account.scss
@@ -43,7 +43,7 @@
     top: 0;
     z-index: $z-above;
     padding: 10px;
-    background-color: $grey-dark;
+    background-color: $grey;
 
     &.is-bottom {
       top: auto;
@@ -120,7 +120,7 @@
             border: none;
             border-radius: $round-corner;
             color: $charcoal-opacity-dark;
-            background-color: lighten($grey-dark, 5%);
+            background-color: lighten($grey, 5%);
             line-height: 1em;
             text-align: left;
             cursor: pointer;

--- a/themes/ddbasic/sass/components/panel/account.scss
+++ b/themes/ddbasic/sass/components/panel/account.scss
@@ -43,7 +43,11 @@
     top: 0;
     z-index: $z-above;
     padding: 10px;
-    background-color: $grey;
+    background-color: $white;
+    border-top: 1px solid #e5e5e5;
+    border-left: 1px solid #e5e5e5;
+    border-right: 1px solid #e5e5e5;
+    border-radius: 4px 4px 0 0;
 
     &.is-bottom {
       top: auto;
@@ -72,10 +76,6 @@
         position: static;
 
         @include transform(translateY(0%));
-      }
-
-      label {
-        color: $white;
       }
     }
 
@@ -194,6 +194,11 @@
         }
       }
     }
+  }
+
+
+  .form-checkbox {
+    border-color: $grey-dark;
   }
 }
 

--- a/themes/ddbasic/sass/components/ting-object/material-item.scss
+++ b/themes/ddbasic/sass/components/ting-object/material-item.scss
@@ -261,7 +261,7 @@
     }
   }
   &.odd {
-    background-color: $grey;
+    background-color: $grey-light;
 
     // Mobile
     @include media($mobile) {

--- a/themes/ddbasic/sass/components/ting-object/material-item.scss
+++ b/themes/ddbasic/sass/components/ting-object/material-item.scss
@@ -261,7 +261,7 @@
     }
   }
   &.odd {
-    background-color: $grey-medium;
+    background-color: $grey;
 
     // Mobile
     @include media($mobile) {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5138?issue_count=93&issue_position=9&next_issue_id=5132&prev_issue_id=5139

#### Description

The use of $grey-dark(#808285) creates issues with contrast to the text content on top of it. 

#### Screenshot of the result

Screenshot of the same background. But in a different context.
![Screenshot 2021-06-16 at 13 15 41](https://user-images.githubusercontent.com/332915/122212170-d565a200-cea7-11eb-9529-d96dfb0ef5f9.png)


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions


